### PR TITLE
Feature: implement CDN URL to song ID reverse lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,21 +137,8 @@ delete: [ ]
 
 ```yaml
 prepend:
-  - 'AND,((DOMAIN,api.pypy.dance),(PROCESS-NAME-REGEX,VRChat)),vrcDancePreload'
-  - 'AND,((DOMAIN,api.pypy.dance),(PROCESS-NAME-REGEX,yt-dlp)),vrcDancePreload'
-  - 'AND,((DOMAIN,api.udon.dance),(PROCESS-NAME-REGEX,VRChat)),vrcDancePreload'
-  - 'AND,((DOMAIN,api.udon.dance),(PROCESS-NAME-REGEX,yt-dlp)),vrcDancePreload'
-append: [ ]
-delete: [ ]
-```
-
-**如果你同时使用加速器和Clash，可能需要增加放行VRChat流量的规则：**
-```yaml
-prepend:
-  - 'DOMAIN-SUFFIX,vrchat.com,DIRECT'
-  - 'DOMAIN-SUFFIX,vrchat.cloud,DIRECT'
-  - 'AND,((DOMAIN,api.pypy.dance),(PROCESS-NAME-REGEX,VRChat)),vrcDancePreload'
-  - 'AND,((DOMAIN,api.pypy.dance),(PROCESS-NAME-REGEX,yt-dlp)),vrcDancePreload'
+  - 'AND,((DOMAIN-SUFFIX,pypy.dance),(PROCESS-NAME-REGEX,VRChat)),vrcDancePreload'
+  - 'AND,((DOMAIN-SUFFIX,pypy.dance),(PROCESS-NAME-REGEX,yt-dlp)),vrcDancePreload'
   - 'AND,((DOMAIN,api.udon.dance),(PROCESS-NAME-REGEX,VRChat)),vrcDancePreload'
   - 'AND,((DOMAIN,api.udon.dance),(PROCESS-NAME-REGEX,yt-dlp)),vrcDancePreload'
 append: [ ]

--- a/internal/cache/entry_url.go
+++ b/internal/cache/entry_url.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/wzhqwq/VRCDancePreloader/internal/persistence"
 	"github.com/wzhqwq/VRCDancePreloader/internal/requesting"
 	"github.com/wzhqwq/VRCDancePreloader/internal/utils"
 )
@@ -71,6 +72,9 @@ func (e *UrlBasedEntry) resolveRemoteMedia(ctx context.Context) error {
 	e.remoteSize = info.TotalSize
 	e.resolvedUrl = url
 	e.logger.InfoLn(e.id, "resolved to", url, "size:", e.remoteSize, "modified time:", e.remoteModTime.Local().String())
+
+	// Save CDN URL to song ID mapping for reverse lookup
+	persistence.SaveCdnUrlMapping(e.id, url)
 
 	return nil
 }

--- a/internal/constants/sites.go
+++ b/internal/constants/sites.go
@@ -1,12 +1,15 @@
 package constants
 
 import (
+	"strings"
+
 	"github.com/samber/lo"
 )
 
 var pypySites = []string{
 	//"jd.pypy.moe",
 	"api.pypy.dance",
+	"cdn.pypy.dance",
 }
 var wannaSites = []string{
 	"api.udon.dance",
@@ -50,7 +53,9 @@ var httpsSites = []string{
 }
 
 func IsPyPySite(host string) bool {
-	return lo.IndexOf(pypySites, host) >= 0
+	return lo.IndexOf(pypySites, host) >= 0 ||
+		strings.HasSuffix(host, ".api.pypy.dance") ||
+		strings.HasSuffix(host, ".cdn.pypy.dance")
 }
 func IsWannaSite(host string) bool {
 	return lo.IndexOf(wannaSites, host) >= 0

--- a/internal/hijack/video_handler.go
+++ b/internal/hijack/video_handler.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"path/filepath"
+	"strconv"
 	"sync"
 
 	"github.com/wzhqwq/VRCDancePreloader/internal/constants"
+	"github.com/wzhqwq/VRCDancePreloader/internal/persistence"
 	"github.com/wzhqwq/VRCDancePreloader/internal/playlist"
 	"github.com/wzhqwq/VRCDancePreloader/internal/utils"
 )
@@ -89,6 +92,16 @@ func handlePypyRequest(w http.ResponseWriter, req *http.Request, wg *sync.WaitGr
 	}
 	if id, ok := utils.CheckPyPyRequest(req); ok {
 		return handlePlatformVideoRequest("PyPyDance", id, w, req, wg)
+	}
+	// Try reverse lookup from CDN URL filename
+	filename := filepath.Base(req.URL.Path)
+	if filename != "" && filename != "." && filename != "/" {
+		if songID, ok := persistence.FindSongIDByCdnFilename(filename); ok && songID != "" {
+			// Extract numeric ID from pypy_xxxx format
+			if num, ok := utils.CheckIdIsPyPy(songID); ok {
+				return handlePlatformVideoRequest("PyPyDance", strconv.Itoa(num), w, req, wg)
+			}
+		}
 	}
 	return false
 }

--- a/internal/persistence/cdn_mapping.go
+++ b/internal/persistence/cdn_mapping.go
@@ -1,0 +1,122 @@
+package persistence
+
+import (
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/wzhqwq/VRCDancePreloader/internal/utils"
+)
+
+var cdnMappingLogger = utils.NewLogger("CDN Mapping")
+
+// cdnMappingCache 内存缓存，避免频繁查询数据库
+var cdnMappingCache = make(map[string]string) // cdn_filename -> song_id
+var cdnMappingMutex sync.RWMutex
+
+const cdnUrlMappingTableSQL = `
+CREATE TABLE IF NOT EXISTS cdn_url_mapping (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	song_id TEXT NOT NULL,
+	cdn_filename TEXT NOT NULL UNIQUE,
+	full_url TEXT,
+	updated_at INTEGER
+);
+`
+
+// InitCdnUrlMapping 初始化CDN映射表
+func InitCdnUrlMapping() error {
+	_, err := DB.Exec(cdnUrlMappingTableSQL)
+	if err != nil {
+		return err
+	}
+	// 加载现有映射到内存缓存
+	return loadCdnMappingsToCache()
+}
+
+// loadCdnMappingsToCache 从数据库加载映射到内存缓存
+func loadCdnMappingsToCache() error {
+	cdnMappingMutex.Lock()
+	defer cdnMappingMutex.Unlock()
+
+	rows, err := DB.Query("SELECT cdn_filename, song_id FROM cdn_url_mapping")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var filename, songID string
+		if err := rows.Scan(&filename, &songID); err != nil {
+			continue
+		}
+		cdnMappingCache[filename] = songID
+	}
+	return nil
+}
+
+// SaveCdnUrlMapping 保存CDN URL到视频ID的映射
+func SaveCdnUrlMapping(songID, cdnUrl string) {
+	// 从URL中提取文件名
+	filename := filepath.Base(cdnUrl)
+	if filename == "" || filename == "." {
+		return
+	}
+
+	cdnMappingMutex.Lock()
+	defer cdnMappingMutex.Unlock()
+
+	// 检查是否已存在相同的映射
+	if existingID, ok := cdnMappingCache[filename]; ok && existingID == songID {
+		return
+	}
+
+	// 更新内存缓存
+	cdnMappingCache[filename] = songID
+
+	// 异步保存到数据库
+	go func() {
+		_, err := DB.Exec(
+			"INSERT OR REPLACE INTO cdn_url_mapping (song_id, cdn_filename, full_url, updated_at) VALUES (?, ?, ?, ?)",
+			songID, filename, cdnUrl, time.Now().Unix(),
+		)
+		if err != nil {
+			cdnMappingLogger.ErrorLn("Failed to save CDN mapping:", err)
+		}
+	}()
+}
+
+// FindSongIDByCdnUrl 根据CDN URL查找对应的视频ID
+func FindSongIDByCdnUrl(cdnUrl string) (string, bool) {
+	filename := filepath.Base(cdnUrl)
+	if filename == "" || filename == "." {
+		return "", false
+	}
+	return FindSongIDByCdnFilename(filename)
+}
+
+// FindSongIDByCdnFilename 根据CDN文件名查找对应的视频ID
+func FindSongIDByCdnFilename(filename string) (string, bool) {
+	cdnMappingMutex.RLock()
+	defer cdnMappingMutex.RUnlock()
+
+	songID, ok := cdnMappingCache[filename]
+	return songID, ok
+}
+
+// IsPyPyCdnUrl 检查是否是PyPy CDN的URL
+func IsPyPyCdnUrl(host, path string) bool {
+	return strings.Contains(host, "pypy.dance") && strings.HasSuffix(path, ".mp4")
+}
+
+// IsWannaCdnUrl 检查是否是WannaDance CDN的URL
+func IsWannaCdnUrl(host, path string) bool {
+	return (strings.Contains(host, "wannadance") || strings.Contains(host, "udon.dance")) &&
+		strings.Contains(path, ".mp4")
+}
+
+// IsDuDuCdnUrl 检查是否是DuDu CDN的URL
+func IsDuDuCdnUrl(host, path string) bool {
+	return strings.Contains(host, "dudufit.dance") && strings.Contains(path, ".mp4")
+}

--- a/internal/persistence/db.go
+++ b/internal/persistence/db.go
@@ -44,6 +44,13 @@ func InitDB(dbFilePath string) error {
 		return err
 	}
 
+	_, err = DB.Exec(cdnUrlMappingTableSQL)
+	if err != nil {
+		return err
+	}
+
+	InitCdnUrlMapping()
+
 	InitLocalSongs()
 	InitAllowList()
 	InitLocalRecords()

--- a/internal/utils/pypy.go
+++ b/internal/utils/pypy.go
@@ -58,7 +58,7 @@ func CheckPyPyRequest(req *http.Request) (string, bool) {
 }
 
 func CheckPyPyResource(url string) bool {
-	return strings.Contains(url, "api.pypy.dance") || strings.Contains(url, "jd.pypy.moe")
+	return strings.Contains(url, "pypy.dance") || strings.Contains(url, "jd.pypy.moe")
 }
 
 func CheckIdIsPyPy(id string) (int, bool) {


### PR DESCRIPTION
Feature: 实现 CDN URL 到视频 ID 的反向映射，修复 PyPy CDN 缓存未命中问题
https://github.com/wzhqwq/VRCDancePreloader/issues/4
<img width="468" height="719" alt="image" src="https://github.com/user-attachments/assets/6f6482fc-ef39-41e8-892f-857a0cb3c696" />
支持了对 cdn.pypy.dance和这类806bb815.cdn.pypy.dance拓展cdn域名的支持。

问题背景：
PyPy CDN 使用随机哈希文件名（如 /qio1iXG2gvM.mp4），而现有 URL 匹配逻辑
仅支持标准格式（/videos/12345.mp4 或 /video?id=12345），导致 CDN 请求无法
识别对应视频 ID，缓存系统完全失效。

解决方案：
1. 新增 cdn_url_mapping 数据库表，持久化存储 CDN 文件名到歌曲 ID 的映射关系
2. 在 UrlBasedEntry.resolveRemoteMedia() 解析视频 URL 时，自动保存映射到数据库
3. 扩展 handlePypyRequest() 支持反向查找：当标准匹配失败时，通过 CDN 文件名
   查询对应歌曲 ID，实现缓存命中

技术实现：
- 内存缓存（map）+ SQLite 双级存储，避免频繁查询数据库
- 异步写入数据库，不阻塞视频下载流程
- 复用现有 CheckIdIsPyPy 提取数字 ID，兼容原有缓存系统

附加变更：
- 添加缺失的 live/web 静态文件（embed 依赖）
- 清理调试日志

影响范围：
- PyPyDance CDN 请求现在能正确命中本地缓存
- 显著减少视频重复下载，降低带宽消耗
